### PR TITLE
Rename error callback parameter to 'err'

### DIFF
--- a/index.js
+++ b/index.js
@@ -291,7 +291,7 @@ Mogile.prototype.sendCommand = function(cmd, callback)
 		$this.current_tracker = trackers[i];
 		var connection = net.createConnection($this.current_tracker.getPort(), $this.current_tracker.getHost());
 		connection.setEncoding($this.encoding);
-		connection.on('error', function(e) {
+		connection.on('error', function(err) {
 			i++;
 			if (i == $this.trackers.length) {
 				callback(err);


### PR DESCRIPTION
Line 297 fails with an error - `err is not defined`. This patch renames the callback parameter from `e` to `err` to fix the issue. :) 